### PR TITLE
New class-based API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+0.7.0
+-----
+
+* Added `Control.Concurrent...Class` modules with typeclasses for overloaded
+  operations. Functions like `putMVar` now work on both `WriteOnlyMVar` and
+  `MVar`.
+
+* Export list updated. Importing `Control.Concurrent.Privilege` should now be
+  enough for all use cases.
+
 0.6.2
 -----
 

--- a/Control/Concurrent/Chan/Class.hs
+++ b/Control/Concurrent/Chan/Class.hs
@@ -1,7 +1,7 @@
 module Control.Concurrent.Chan.Class where
 
-import qualified UnliftIO.Chan as Chan
 import Control.Monad.IO.Unlift
+import qualified UnliftIO.Chan as Chan
 
 class ChanDup chan where
     dupChan :: MonadIO m => chan a -> m (chan a)
@@ -23,3 +23,7 @@ instance ChanWrite Chan.Chan where
 
 class ChanRead chan where
     readChan :: MonadIO m => chan a -> m a
+
+instance ChanRead Chan.Chan where
+    readChan = Chan.readChan
+    {-# INLINE readChan #-}

--- a/Control/Concurrent/Chan/Class.hs
+++ b/Control/Concurrent/Chan/Class.hs
@@ -1,0 +1,25 @@
+module Control.Concurrent.Chan.Class where
+
+import qualified UnliftIO.Chan as Chan
+import Control.Monad.IO.Unlift
+
+class ChanDup chan where
+    dupChan :: MonadIO m => chan a -> m (chan a)
+
+instance ChanDup Chan.Chan where
+    dupChan = Chan.dupChan
+    {-# INLINE dupChan #-}
+
+class ChanWrite chan where
+    writeChan :: MonadIO m => chan a -> a -> m ()
+    writeList2Chan :: MonadIO m => chan a -> [a] -> m ()
+
+instance ChanWrite Chan.Chan where
+    writeChan = Chan.writeChan
+    {-# INLINE writeChan #-}
+
+    writeList2Chan = Chan.writeList2Chan
+    {-# INLINE writeList2Chan #-}
+
+class ChanRead chan where
+    readChan :: MonadIO m => chan a -> m a

--- a/Control/Concurrent/Chan/ReadOnly.hs
+++ b/Control/Concurrent/Chan/ReadOnly.hs
@@ -5,23 +5,23 @@ module Control.Concurrent.Chan.ReadOnly
   , toReadOnlyChan
   ) where
 
-import qualified UnliftIO.Chan as Chan
+import Control.Concurrent.Chan (Chan)
 import Control.Concurrent.Chan.Class
 
-data ReadOnlyChan b = forall a . ReadOnlyChan (Chan.Chan a) (a -> b)
+data ReadOnlyChan b = forall a . ReadOnlyChan (Chan a) (a -> b)
 
 instance Functor ReadOnlyChan where
   fmap f (ReadOnlyChan c f') = ReadOnlyChan c (f . f')
 
-toReadOnlyChan :: Chan.Chan a -> ReadOnlyChan a
+toReadOnlyChan :: Chan a -> ReadOnlyChan a
 toReadOnlyChan c = ReadOnlyChan c id
 
 instance ChanDup ReadOnlyChan where
     dupChan (ReadOnlyChan chan f) = do
-      chan' <- Chan.dupChan chan
+      chan' <- dupChan chan
       return (ReadOnlyChan chan' f)
     {-# INLINE dupChan #-}
 
 instance ChanRead ReadOnlyChan where
-    readChan (ReadOnlyChan chan f) = f <$> Chan.readChan chan
+    readChan (ReadOnlyChan chan f) = f <$> readChan chan
     {-# INLINE readChan #-}

--- a/Control/Concurrent/Chan/ReadOnly.hs
+++ b/Control/Concurrent/Chan/ReadOnly.hs
@@ -1,34 +1,27 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.Chan.ReadOnly
-( ReadOnlyChan
-, toReadOnlyChan
-, readChan
-, dupReadOnlyChan
-, getChanContents
-) where
+  ( ReadOnlyChan
+  , toReadOnlyChan
+  ) where
 
-import           Control.Concurrent.Chan.Lifted (Chan)
-import qualified Control.Concurrent.Chan.Lifted as Chan
-import           Control.Monad.Base
+import qualified UnliftIO.Chan as Chan
+import Control.Concurrent.Chan.Class
 
-data ReadOnlyChan b = forall a . ReadOnlyChan (Chan a) (a -> b)
+data ReadOnlyChan b = forall a . ReadOnlyChan (Chan.Chan a) (a -> b)
 
 instance Functor ReadOnlyChan where
   fmap f (ReadOnlyChan c f') = ReadOnlyChan c (f . f')
 
-toReadOnlyChan :: Chan a -> ReadOnlyChan a
+toReadOnlyChan :: Chan.Chan a -> ReadOnlyChan a
 toReadOnlyChan c = ReadOnlyChan c id
 
-readChan :: MonadBase IO m => ReadOnlyChan a -> m a
-readChan (ReadOnlyChan chan f) =
-  f <$> Chan.readChan chan
+instance ChanDup ReadOnlyChan where
+    dupChan (ReadOnlyChan chan f) = do
+      chan' <- Chan.dupChan chan
+      return (ReadOnlyChan chan' f)
+    {-# INLINE dupChan #-}
 
-dupReadOnlyChan :: MonadBase IO m => ReadOnlyChan a -> m (ReadOnlyChan a)
-dupReadOnlyChan (ReadOnlyChan chan f) = do
-  dup <- Chan.dupChan chan
-  return (ReadOnlyChan dup f)
-
-getChanContents :: MonadBase IO m => ReadOnlyChan a -> m [a]
-getChanContents (ReadOnlyChan chan f) =
-  fmap f <$> Chan.getChanContents chan
+instance ChanRead ReadOnlyChan where
+    readChan (ReadOnlyChan chan f) = f <$> Chan.readChan chan
+    {-# INLINE readChan #-}

--- a/Control/Concurrent/Chan/WriteOnly.hs
+++ b/Control/Concurrent/Chan/WriteOnly.hs
@@ -5,27 +5,27 @@ module Control.Concurrent.Chan.WriteOnly
   , toWriteOnlyChan
   ) where
 
+import Control.Concurrent.Chan (Chan)
 import Control.Concurrent.Chan.Class
 import Data.Functor.Contravariant
-import qualified UnliftIO.Chan as Chan
 
-data WriteOnlyChan a = forall b . WriteOnlyChan (a -> b) (Chan.Chan b)
+data WriteOnlyChan a = forall b . WriteOnlyChan (a -> b) (Chan b)
 
 instance Contravariant WriteOnlyChan where
   contramap f (WriteOnlyChan f' c) = WriteOnlyChan (f' . f) c
 
-toWriteOnlyChan :: Chan.Chan a -> WriteOnlyChan a
+toWriteOnlyChan :: Chan a -> WriteOnlyChan a
 toWriteOnlyChan = WriteOnlyChan id
 
 instance ChanDup WriteOnlyChan where
     dupChan (WriteOnlyChan f chan) = do
-      chan' <- Chan.dupChan chan
+      chan' <- dupChan chan
       return (WriteOnlyChan f chan')
     {-# INLINE dupChan #-}
 
 instance ChanWrite WriteOnlyChan where
-    writeChan (WriteOnlyChan f chan) = Chan.writeChan chan . f
+    writeChan (WriteOnlyChan f chan) = writeChan chan . f
     {-# INLINE writeChan #-}
 
-    writeList2Chan (WriteOnlyChan f chan) = Chan.writeList2Chan chan . map f
+    writeList2Chan (WriteOnlyChan f chan) = writeList2Chan chan . map f
     {-# INLINE writeList2Chan #-}

--- a/Control/Concurrent/MVar/Class.hs
+++ b/Control/Concurrent/MVar/Class.hs
@@ -1,0 +1,38 @@
+module Control.Concurrent.MVar.Class where
+
+import qualified UnliftIO.MVar as MVar
+import Control.Monad.IO.Unlift
+
+class MVarWrite var where
+    putMVar :: MonadIO m => var a -> a -> m ()
+    tryPutMVar :: MonadIO m => var a -> a -> m Bool
+
+instance MVarWrite MVar.MVar where
+    putMVar = MVar.putMVar
+    {-# INLINE putMVar #-}
+
+    tryPutMVar = MVar.tryPutMVar
+    {-# INLINE tryPutMVar #-}
+
+class MVarRead var where
+    takeMVar :: MonadIO m => var a -> m a
+    readMVar :: MonadIO m => var a -> m a
+    tryReadMVar :: MonadIO m => var a -> m (Maybe a)
+    tryTakeMVar :: MonadIO m => var a -> m (Maybe a)
+    withMVar :: MonadUnliftIO m => var a -> (a -> m b) -> m b
+
+instance MVarRead MVar.MVar where
+    takeMVar = MVar.takeMVar
+    {-# INLINE takeMVar #-}
+
+    readMVar = MVar.readMVar
+    {-# INLINE readMVar #-}
+
+    tryReadMVar = MVar.tryReadMVar
+    {-# INLINE tryReadMVar #-}
+
+    tryTakeMVar = MVar.tryTakeMVar
+    {-# INLINE tryTakeMVar #-}
+
+    withMVar = MVar.withMVar
+    {-# INLINE withMVar #-}

--- a/Control/Concurrent/MVar/Class.hs
+++ b/Control/Concurrent/MVar/Class.hs
@@ -1,7 +1,7 @@
 module Control.Concurrent.MVar.Class where
 
-import qualified UnliftIO.MVar as MVar
 import Control.Monad.IO.Unlift
+import qualified UnliftIO.MVar as MVar
 
 class MVarWrite var where
     putMVar :: MonadIO m => var a -> a -> m ()

--- a/Control/Concurrent/MVar/ReadOnly.hs
+++ b/Control/Concurrent/MVar/ReadOnly.hs
@@ -5,29 +5,29 @@ module Control.Concurrent.MVar.ReadOnly
   , toReadOnlyMVar
   ) where
 
+import Control.Concurrent.MVar (MVar)
 import Control.Concurrent.MVar.Class
-import qualified UnliftIO.MVar as MVar
 
-data ReadOnlyMVar b = forall a . ReadOnlyMVar (MVar.MVar a) (a -> b)
+data ReadOnlyMVar b = forall a . ReadOnlyMVar (MVar a) (a -> b)
 
 instance Functor ReadOnlyMVar where
   fmap f (ReadOnlyMVar var f') = ReadOnlyMVar var (f . f')
 
-toReadOnlyMVar :: MVar.MVar a -> ReadOnlyMVar a
+toReadOnlyMVar :: MVar a -> ReadOnlyMVar a
 toReadOnlyMVar var = ReadOnlyMVar var id
 
 instance MVarRead ReadOnlyMVar where
-    takeMVar (ReadOnlyMVar var f) = f <$> MVar.takeMVar var
+    takeMVar (ReadOnlyMVar var f) = f <$> takeMVar var
     {-# INLINE takeMVar #-}
 
-    readMVar (ReadOnlyMVar var f) = f <$> MVar.readMVar var
+    readMVar (ReadOnlyMVar var f) = f <$> readMVar var
     {-# INLINE readMVar #-}
 
-    tryReadMVar (ReadOnlyMVar var f) = fmap f <$> MVar.tryReadMVar var
+    tryReadMVar (ReadOnlyMVar var f) = fmap f <$> tryReadMVar var
     {-# INLINE tryReadMVar #-}
 
-    tryTakeMVar (ReadOnlyMVar var f) = fmap f <$> MVar.tryTakeMVar var
+    tryTakeMVar (ReadOnlyMVar var f) = fmap f <$> tryTakeMVar var
     {-# INLINE tryTakeMVar #-}
 
-    withMVar (ReadOnlyMVar var f) w = MVar.withMVar var (w . f)
+    withMVar (ReadOnlyMVar var f) w = withMVar var (w . f)
     {-# INLINE withMVar #-}

--- a/Control/Concurrent/MVar/ReadOnly.hs
+++ b/Control/Concurrent/MVar/ReadOnly.hs
@@ -1,44 +1,33 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.MVar.ReadOnly
-( ReadOnlyMVar
-, toReadOnlyMVar
-, takeMVar
-, readMVar
-, tryReadMVar
-, tryTakeMVar
-, withMVar
-) where
+  ( ReadOnlyMVar
+  , toReadOnlyMVar
+  ) where
 
-import           Control.Concurrent.MVar.Lifted (MVar)
-import qualified Control.Concurrent.MVar.Lifted as MVar
-import           Control.Monad.Base
-import           Control.Monad.Trans.Control    (MonadBaseControl)
+import Control.Concurrent.MVar.Class
+import qualified UnliftIO.MVar as MVar
 
-data ReadOnlyMVar b = forall a . ReadOnlyMVar (MVar a) (a -> b)
+data ReadOnlyMVar b = forall a . ReadOnlyMVar (MVar.MVar a) (a -> b)
 
 instance Functor ReadOnlyMVar where
   fmap f (ReadOnlyMVar var f') = ReadOnlyMVar var (f . f')
 
-toReadOnlyMVar :: MVar a -> ReadOnlyMVar a
+toReadOnlyMVar :: MVar.MVar a -> ReadOnlyMVar a
 toReadOnlyMVar var = ReadOnlyMVar var id
 
-takeMVar :: MonadBase IO m => ReadOnlyMVar a -> m a
-takeMVar (ReadOnlyMVar var f) =
-  f <$> MVar.takeMVar var
+instance MVarRead ReadOnlyMVar where
+    takeMVar (ReadOnlyMVar var f) = f <$> MVar.takeMVar var
+    {-# INLINE takeMVar #-}
 
-readMVar :: MonadBase IO m => ReadOnlyMVar a -> m a
-readMVar (ReadOnlyMVar var f) =
-  f <$> MVar.readMVar var
+    readMVar (ReadOnlyMVar var f) = f <$> MVar.readMVar var
+    {-# INLINE readMVar #-}
 
-tryReadMVar :: MonadBase IO m => ReadOnlyMVar a -> m (Maybe a)
-tryReadMVar (ReadOnlyMVar var f) =
-  fmap f <$> MVar.tryReadMVar var
+    tryReadMVar (ReadOnlyMVar var f) = fmap f <$> MVar.tryReadMVar var
+    {-# INLINE tryReadMVar #-}
 
-tryTakeMVar :: MonadBase IO m => ReadOnlyMVar a -> m (Maybe a)
-tryTakeMVar (ReadOnlyMVar var f) =
-  fmap f <$> MVar.tryTakeMVar var
+    tryTakeMVar (ReadOnlyMVar var f) = fmap f <$> MVar.tryTakeMVar var
+    {-# INLINE tryTakeMVar #-}
 
-withMVar :: MonadBaseControl IO m => ReadOnlyMVar a -> (a -> m b) -> m b
-withMVar (ReadOnlyMVar var f) w =
-  MVar.withMVar var (w . f)
+    withMVar (ReadOnlyMVar var f) w = MVar.withMVar var (w . f)
+    {-# INLINE withMVar #-}

--- a/Control/Concurrent/MVar/WriteOnly.hs
+++ b/Control/Concurrent/MVar/WriteOnly.hs
@@ -1,29 +1,25 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.MVar.WriteOnly
-( WriteOnlyMVar
-, toWriteOnlyMVar
-, putMVar
-, tryPutMVar
-) where
+  ( WriteOnlyMVar
+  , toWriteOnlyMVar
+  ) where
 
-import           Control.Concurrent.MVar.Lifted (MVar)
-import qualified Control.Concurrent.MVar.Lifted as MVar
-import           Control.Monad.Base
-import           Data.Functor.Contravariant
+import Control.Concurrent.MVar.Class
+import Data.Functor.Contravariant
+import qualified UnliftIO.MVar as MVar
 
-data WriteOnlyMVar a = forall b . WriteOnlyMVar (a -> b) (MVar b)
+data WriteOnlyMVar a = forall b . WriteOnlyMVar (a -> b) (MVar.MVar b)
 
 instance Contravariant WriteOnlyMVar where
   contramap f (WriteOnlyMVar f' var) = WriteOnlyMVar (f' . f) var
 
-toWriteOnlyMVar :: MVar a -> WriteOnlyMVar a
+toWriteOnlyMVar :: MVar.MVar a -> WriteOnlyMVar a
 toWriteOnlyMVar = WriteOnlyMVar id
 
-putMVar :: MonadBase IO m => WriteOnlyMVar a -> a -> m ()
-putMVar (WriteOnlyMVar f var) =
-  MVar.putMVar var . f
+instance MVarWrite WriteOnlyMVar where
+    putMVar (WriteOnlyMVar f var) a = MVar.putMVar var (f a)
+    {-# INLINE putMVar #-}
 
-tryPutMVar :: MonadBase IO m => WriteOnlyMVar a -> a -> m Bool
-tryPutMVar (WriteOnlyMVar f var) =
-  MVar.tryPutMVar var . f
+    tryPutMVar (WriteOnlyMVar f var) a = MVar.tryPutMVar var (f a)
+    {-# INLINE tryPutMVar #-}

--- a/Control/Concurrent/MVar/WriteOnly.hs
+++ b/Control/Concurrent/MVar/WriteOnly.hs
@@ -5,21 +5,21 @@ module Control.Concurrent.MVar.WriteOnly
   , toWriteOnlyMVar
   ) where
 
+import Control.Concurrent.MVar (MVar)
 import Control.Concurrent.MVar.Class
 import Data.Functor.Contravariant
-import qualified UnliftIO.MVar as MVar
 
-data WriteOnlyMVar a = forall b . WriteOnlyMVar (a -> b) (MVar.MVar b)
+data WriteOnlyMVar a = forall b . WriteOnlyMVar (a -> b) (MVar b)
 
 instance Contravariant WriteOnlyMVar where
   contramap f (WriteOnlyMVar f' var) = WriteOnlyMVar (f' . f) var
 
-toWriteOnlyMVar :: MVar.MVar a -> WriteOnlyMVar a
+toWriteOnlyMVar :: MVar a -> WriteOnlyMVar a
 toWriteOnlyMVar = WriteOnlyMVar id
 
 instance MVarWrite WriteOnlyMVar where
-    putMVar (WriteOnlyMVar f var) a = MVar.putMVar var (f a)
+    putMVar (WriteOnlyMVar f var) a = putMVar var (f a)
     {-# INLINE putMVar #-}
 
-    tryPutMVar (WriteOnlyMVar f var) a = MVar.tryPutMVar var (f a)
+    tryPutMVar (WriteOnlyMVar f var) a = tryPutMVar var (f a)
     {-# INLINE tryPutMVar #-}

--- a/Control/Concurrent/Privileged.hs
+++ b/Control/Concurrent/Privileged.hs
@@ -1,7 +1,7 @@
 -- | Module: Control.Concurrent.Privileged
 -- Copyright: (c) Jeff Shaw 2012
 -- License: BSD, see the file LICENSE
--- Maintainer: shawjef3@msu.edu
+-- Maintainer: omeragacan@gmail.com
 -- Stability: experimental
 -- Portability: non-portable (concurrency)
 --

--- a/Control/Concurrent/Privileged.hs
+++ b/Control/Concurrent/Privileged.hs
@@ -9,7 +9,6 @@
 
 module Control.Concurrent.Privileged (
 -- * Privilege Separated Concurrent Haskell
-
 module Control.Concurrent.Chan.Class,
 module Control.Concurrent.Chan.ReadOnly,
 module Control.Concurrent.Chan.WriteOnly,
@@ -21,7 +20,23 @@ module Control.Concurrent.STM.TVar.WriteOnly,
 module Control.Concurrent.STM.TMVar.ReadOnly,
 module Control.Concurrent.STM.TMVar.WriteOnly,
 module Control.Concurrent.STM.TChan.ReadOnly,
-module Control.Concurrent.STM.TChan.WriteOnly
+module Control.Concurrent.STM.TChan.WriteOnly,
+-- * Re-exports
+module Control.Monad.IO.Class,
+Chan.Chan,
+Chan.newChan,
+MVar.modifyMVar,
+MVar.modifyMVar_,
+MVar.MVar,
+MVar.newEmptyMVar,
+MVar.newMVar,
+TChan.newTChan,
+TChan.TChan,
+TMVar.newEmptyTMVar,
+TMVar.newTMVar,
+TMVar.TMVar,
+TVar.newTVar,
+TVar.TVar
 ) where
 
 import Control.Concurrent.Chan.Class
@@ -30,12 +45,18 @@ import Control.Concurrent.Chan.WriteOnly
 import Control.Concurrent.MVar.Class
 import Control.Concurrent.MVar.ReadOnly
 import Control.Concurrent.MVar.WriteOnly
-import Control.Concurrent.STM.TVar.ReadOnly
-import Control.Concurrent.STM.TVar.WriteOnly
-import Control.Concurrent.STM.TMVar.ReadOnly
-import Control.Concurrent.STM.TMVar.WriteOnly
+import qualified Control.Concurrent.STM.TChan as TChan
 import Control.Concurrent.STM.TChan.ReadOnly
 import Control.Concurrent.STM.TChan.WriteOnly
+import qualified Control.Concurrent.STM.TMVar as TMVar
+import Control.Concurrent.STM.TMVar.ReadOnly
+import Control.Concurrent.STM.TMVar.WriteOnly
+import qualified Control.Concurrent.STM.TVar as TVar
+import Control.Concurrent.STM.TVar.ReadOnly
+import Control.Concurrent.STM.TVar.WriteOnly
+import Control.Monad.IO.Class
+import qualified UnliftIO.Chan as Chan
+import qualified UnliftIO.MVar as MVar
 
 {- $intro
 

--- a/Control/Concurrent/Privileged.hs
+++ b/Control/Concurrent/Privileged.hs
@@ -8,10 +8,12 @@
 -- Privilege separated concurrency abstractions.
 
 module Control.Concurrent.Privileged (
--- * Privelege Seperated Concurrent Haskell
+-- * Privilege Separated Concurrent Haskell
 
+module Control.Concurrent.Chan.Class,
 module Control.Concurrent.Chan.ReadOnly,
 module Control.Concurrent.Chan.WriteOnly,
+module Control.Concurrent.MVar.Class,
 module Control.Concurrent.MVar.ReadOnly,
 module Control.Concurrent.MVar.WriteOnly,
 module Control.Concurrent.STM.TVar.ReadOnly,
@@ -22,8 +24,10 @@ module Control.Concurrent.STM.TChan.ReadOnly,
 module Control.Concurrent.STM.TChan.WriteOnly
 ) where
 
+import Control.Concurrent.Chan.Class
 import Control.Concurrent.Chan.ReadOnly
 import Control.Concurrent.Chan.WriteOnly
+import Control.Concurrent.MVar.Class
 import Control.Concurrent.MVar.ReadOnly
 import Control.Concurrent.MVar.WriteOnly
 import Control.Concurrent.STM.TVar.ReadOnly

--- a/Control/Concurrent/STM/TChan/Class.hs
+++ b/Control/Concurrent/STM/TChan/Class.hs
@@ -1,0 +1,45 @@
+module Control.Concurrent.STM.TChan.Class where
+
+import Control.Concurrent.STM
+import qualified Control.Concurrent.STM.TChan as TChan
+
+class TChanDup chan where
+    dupTChan :: chan a -> STM (chan a)
+
+instance TChanDup TChan.TChan where
+    dupTChan = TChan.dupTChan
+    {-# INLINE dupTChan #-}
+
+class TChanWrite chan where
+    writeTChan :: chan a -> a -> STM ()
+    unGetTChan :: chan a -> a -> STM ()
+    isEmptyTChan :: chan a -> STM Bool
+
+instance TChanWrite TChan.TChan where
+    writeTChan = TChan.writeTChan
+    {-# INLINE writeTChan #-}
+
+    unGetTChan = TChan.unGetTChan
+    {-# INLINE unGetTChan #-}
+
+    isEmptyTChan = TChan.isEmptyTChan
+    {-# INLINE isEmptyTChan #-}
+
+class TChanRead chan where
+    readTChan :: chan a -> STM a
+    tryReadTChan :: chan a -> STM (Maybe a)
+    peekTChan :: chan a -> STM a
+    tryPeekTChan :: chan a -> STM (Maybe a)
+
+instance TChanRead TChan.TChan where
+    readTChan = TChan.readTChan
+    {-# INLINE readTChan #-}
+
+    tryReadTChan = TChan.tryReadTChan
+    {-# INLINE tryReadTChan #-}
+
+    peekTChan = TChan.peekTChan
+    {-# INLINE peekTChan #-}
+
+    tryPeekTChan = TChan.tryPeekTChan
+    {-# INLINE tryPeekTChan #-}

--- a/Control/Concurrent/STM/TChan/ReadOnly.hs
+++ b/Control/Concurrent/STM/TChan/ReadOnly.hs
@@ -1,41 +1,32 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.STM.TChan.ReadOnly
-( ReadOnlyTChan
-, toReadOnlyTChan
-, readTChan
-, tryReadTChan
-, peekTChan
-, tryPeekTChan
-, dupReadOnlyTChan
-) where
+  ( ReadOnlyTChan
+  , toReadOnlyTChan
+  ) where
 
-import           Control.Concurrent.STM       (STM)
-import           Control.Concurrent.STM.TChan (TChan)
-import qualified Control.Concurrent.STM.TChan as TChan
+import Control.Concurrent.STM.TChan (TChan)
+import Control.Concurrent.STM.TChan.Class
 
 data ReadOnlyTChan b = forall a . ReadOnlyTChan (TChan a) (a -> b)
 
 toReadOnlyTChan :: TChan a -> ReadOnlyTChan a
 toReadOnlyTChan chan = ReadOnlyTChan chan id
 
-readTChan :: ReadOnlyTChan a -> STM a
-readTChan (ReadOnlyTChan chan f) =
-  f <$> TChan.readTChan chan
+instance TChanDup ReadOnlyTChan where
+    dupTChan (ReadOnlyTChan chan f) = do
+      chan' <- dupTChan chan
+      return (ReadOnlyTChan chan' f)
 
-tryReadTChan :: ReadOnlyTChan a -> STM (Maybe a)
-tryReadTChan (ReadOnlyTChan chan f) =
-  fmap f <$> TChan.tryReadTChan chan
+instance TChanRead ReadOnlyTChan where
+    readTChan (ReadOnlyTChan chan f) = f <$> readTChan chan
+    {-# INLINE readTChan #-}
 
-peekTChan :: ReadOnlyTChan a -> STM a
-peekTChan (ReadOnlyTChan chan f) =
-  f <$> TChan.peekTChan chan
+    tryReadTChan (ReadOnlyTChan chan f) = fmap f <$> tryReadTChan chan
+    {-# INLINE tryReadTChan #-}
 
-tryPeekTChan :: ReadOnlyTChan a -> STM (Maybe a)
-tryPeekTChan (ReadOnlyTChan chan f) =
-  fmap f <$> TChan.tryPeekTChan chan
+    peekTChan (ReadOnlyTChan chan f) = f <$> peekTChan chan
+    {-# INLINE peekTChan #-}
 
-dupReadOnlyTChan :: ReadOnlyTChan a -> STM (ReadOnlyTChan a)
-dupReadOnlyTChan (ReadOnlyTChan chan f) = do
-  dup <- TChan.dupTChan chan
-  return (ReadOnlyTChan dup f)
+    tryPeekTChan (ReadOnlyTChan chan f) = fmap f <$> tryPeekTChan chan
+    {-# INLINE tryPeekTChan #-}

--- a/Control/Concurrent/STM/TMVar/Class.hs
+++ b/Control/Concurrent/STM/TMVar/Class.hs
@@ -1,0 +1,30 @@
+module Control.Concurrent.STM.TMVar.Class where
+
+import Control.Concurrent.STM (STM)
+import qualified Control.Concurrent.STM.TMVar as TMVar
+
+class TMVarWrite var where
+    putTMVar :: var a -> a -> STM ()
+    tryPutTMVar :: var a -> a -> STM Bool
+
+instance TMVarWrite TMVar.TMVar where
+    putTMVar = TMVar.putTMVar
+    {-# INLINE putTMVar #-}
+
+    tryPutTMVar = TMVar.tryPutTMVar
+    {-# INLINE tryPutTMVar #-}
+
+class TMVarRead var where
+    takeTMVar :: var a -> STM a
+    readTMVar :: var a -> STM a
+    tryTakeTMVar :: var a -> STM (Maybe a)
+
+instance TMVarRead TMVar.TMVar where
+    takeTMVar = TMVar.takeTMVar
+    {-# INLINE takeTMVar #-}
+
+    readTMVar = TMVar.readTMVar
+    {-# INLINE readTMVar #-}
+
+    tryTakeTMVar = TMVar.tryTakeTMVar
+    {-# INLINE tryTakeTMVar #-}

--- a/Control/Concurrent/STM/TMVar/ReadOnly.hs
+++ b/Control/Concurrent/STM/TMVar/ReadOnly.hs
@@ -1,35 +1,24 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.STM.TMVar.ReadOnly
-( ReadOnlyTMVar
-, toReadOnlyTMVar
-, takeTMVar
-, readTMVar
-, tryTakeTMVar
-, isEmptyTMVar
-) where
+  ( ReadOnlyTMVar
+  , toReadOnlyTMVar
+  ) where
 
-import           Control.Concurrent.STM       (STM)
-import           Control.Concurrent.STM.TMVar (TMVar)
-import qualified Control.Concurrent.STM.TMVar as TMVar
+import Control.Concurrent.STM.TMVar (TMVar)
+import Control.Concurrent.STM.TMVar.Class
 
 data ReadOnlyTMVar b = forall a . ReadOnlyTMVar (TMVar a) (a -> b)
 
 toReadOnlyTMVar :: TMVar a -> ReadOnlyTMVar a
 toReadOnlyTMVar var = ReadOnlyTMVar var id
 
-takeTMVar :: ReadOnlyTMVar a -> STM a
-takeTMVar (ReadOnlyTMVar var f) =
-  f <$> TMVar.takeTMVar var
+instance TMVarRead ReadOnlyTMVar where
+    takeTMVar (ReadOnlyTMVar var f) = f <$> takeTMVar var
+    {-# INLINE takeTMVar #-}
 
-readTMVar :: ReadOnlyTMVar a -> STM a
-readTMVar (ReadOnlyTMVar var f) =
-  f <$> TMVar.readTMVar var
+    readTMVar (ReadOnlyTMVar var f) = f <$> readTMVar var
+    {-# INLINE readTMVar #-}
 
-tryTakeTMVar :: ReadOnlyTMVar a -> STM (Maybe a)
-tryTakeTMVar (ReadOnlyTMVar var f) =
-  fmap f <$> TMVar.tryTakeTMVar var
-
-isEmptyTMVar :: ReadOnlyTMVar a -> STM Bool
-isEmptyTMVar (ReadOnlyTMVar var _) =
-  TMVar.isEmptyTMVar var
+    tryTakeTMVar (ReadOnlyTMVar var f) = fmap f <$> tryTakeTMVar var
+    {-# INLINE tryTakeTMVar #-}

--- a/Control/Concurrent/STM/TMVar/WriteOnly.hs
+++ b/Control/Concurrent/STM/TMVar/WriteOnly.hs
@@ -1,17 +1,13 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.STM.TMVar.WriteOnly
-( WriteOnlyTMVar
-, toWriteOnlyTMVar
-, putTMVar
-, tryPutTMVar
-, isEmptyWriteOnlyTMVar
-) where
+  ( WriteOnlyTMVar
+  , toWriteOnlyTMVar
+  ) where
 
-import           Control.Concurrent.STM       (STM)
-import           Control.Concurrent.STM.TMVar (TMVar)
-import qualified Control.Concurrent.STM.TMVar as TMVar
-import           Data.Functor.Contravariant
+import Control.Concurrent.STM.TMVar (TMVar)
+import Control.Concurrent.STM.TMVar.Class
+import Data.Functor.Contravariant
 
 data WriteOnlyTMVar a = forall b . WriteOnlyTMVar (a -> b) (TMVar b)
 
@@ -21,14 +17,9 @@ instance Contravariant WriteOnlyTMVar where
 toWriteOnlyTMVar :: TMVar a -> WriteOnlyTMVar a
 toWriteOnlyTMVar = WriteOnlyTMVar id
 
-putTMVar :: WriteOnlyTMVar a -> a -> STM ()
-putTMVar (WriteOnlyTMVar f var) =
-  TMVar.putTMVar var . f
+instance TMVarWrite WriteOnlyTMVar where
+    putTMVar (WriteOnlyTMVar f var) = putTMVar var . f
+    {-# INLINE putTMVar #-}
 
-tryPutTMVar :: WriteOnlyTMVar a -> a -> STM Bool
-tryPutTMVar (WriteOnlyTMVar f var) =
-  TMVar.tryPutTMVar var . f
-
-isEmptyWriteOnlyTMVar :: WriteOnlyTMVar a -> STM Bool
-isEmptyWriteOnlyTMVar (WriteOnlyTMVar _ var) =
-  TMVar.isEmptyTMVar var
+    tryPutTMVar (WriteOnlyTMVar f var) = tryPutTMVar var . f
+    {-# INLINE tryPutTMVar #-}

--- a/Control/Concurrent/STM/TVar/Class.hs
+++ b/Control/Concurrent/STM/TVar/Class.hs
@@ -1,0 +1,18 @@
+module Control.Concurrent.STM.TVar.Class where
+
+import Control.Concurrent.STM (STM)
+import qualified Control.Concurrent.STM.TVar as TVar
+
+class TVarWrite var where
+    writeTVar :: var a -> a -> STM ()
+
+instance TVarWrite TVar.TVar where
+    writeTVar = TVar.writeTVar
+    {-# INLINE writeTVar #-}
+
+class TVarRead var where
+    readTVar :: var a -> STM a
+
+instance TVarRead TVar.TVar where
+    readTVar = TVar.readTVar
+    {-# INLINE readTVar #-}

--- a/Control/Concurrent/STM/TVar/ReadOnly.hs
+++ b/Control/Concurrent/STM/TVar/ReadOnly.hs
@@ -1,25 +1,18 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.STM.TVar.ReadOnly
-( ReadOnlyTVar
-, toReadOnlyTVar
-, readTVar
-, readTVarIO
-) where
+  ( ReadOnlyTVar
+  , toReadOnlyTVar
+  ) where
 
-import           Control.Concurrent.STM      (STM)
-import           Control.Concurrent.STM.TVar (TVar)
-import qualified Control.Concurrent.STM.TVar as TVar
+import Control.Concurrent.STM.TVar (TVar)
+import Control.Concurrent.STM.TVar.Class
 
 data ReadOnlyTVar b = forall a . ReadOnlyTVar (TVar a) (a -> b)
 
 toReadOnlyTVar :: TVar a -> ReadOnlyTVar a
 toReadOnlyTVar var = ReadOnlyTVar var id
 
-readTVar :: ReadOnlyTVar a -> STM a
-readTVar (ReadOnlyTVar var f) =
-  f <$> TVar.readTVar var
-
-readTVarIO :: ReadOnlyTVar a -> IO a
-readTVarIO (ReadOnlyTVar var f) =
-  f <$> TVar.readTVarIO var
+instance TVarRead ReadOnlyTVar where
+    readTVar (ReadOnlyTVar var f) = f <$> readTVar var
+    {-# INLINE readTVar #-}

--- a/Control/Concurrent/STM/TVar/WriteOnly.hs
+++ b/Control/Concurrent/STM/TVar/WriteOnly.hs
@@ -1,15 +1,13 @@
 {-# LANGUAGE ExistentialQuantification #-}
 
 module Control.Concurrent.STM.TVar.WriteOnly
-( WriteOnlyTVar
-, toWriteOnlyTVar
-, writeTVar
-) where
+  ( WriteOnlyTVar
+  , toWriteOnlyTVar
+  ) where
 
-import           Control.Concurrent.STM      (STM)
-import           Control.Concurrent.STM.TVar (TVar)
-import qualified Control.Concurrent.STM.TVar as TVar
-import           Data.Functor.Contravariant
+import Control.Concurrent.STM.TVar (TVar)
+import Control.Concurrent.STM.TVar.Class
+import Data.Functor.Contravariant
 
 data WriteOnlyTVar a = forall b . WriteOnlyTVar (a -> b) (TVar b)
 
@@ -19,6 +17,6 @@ instance Contravariant WriteOnlyTVar where
 toWriteOnlyTVar :: TVar a -> WriteOnlyTVar a
 toWriteOnlyTVar = WriteOnlyTVar id
 
-writeTVar :: WriteOnlyTVar a -> a -> STM ()
-writeTVar (WriteOnlyTVar f var) =
-  TVar.writeTVar var . f
+instance TVarWrite WriteOnlyTVar where
+    writeTVar (WriteOnlyTVar f var) = writeTVar var . f
+    {-# INLINE writeTVar #-}

--- a/privileged-concurrency.cabal
+++ b/privileged-concurrency.cabal
@@ -1,5 +1,5 @@
 Name:                privileged-concurrency
-Version:             0.6.2
+Version:             0.7.0
 Synopsis:            Provides privilege separated versions of the concurrency primitives.
 
 Description:
@@ -37,12 +37,16 @@ Library
     Control.Concurrent.STM.TMVar.WriteOnly
     Control.Concurrent.STM.TVar.ReadOnly
     Control.Concurrent.STM.TVar.WriteOnly
+    Control.Concurrent.MVar.Class
+    Control.Concurrent.Chan.Class
 
   Build-depends:
     base >= 4 && < 5,
     contravariant,
     lifted-base,
     monad-control,
+    unliftio,
+    unliftio-core,
     stm,
     transformers-base
 

--- a/privileged-concurrency.cabal
+++ b/privileged-concurrency.cabal
@@ -11,7 +11,7 @@ Description:
 
 License:             BSD3
 License-file:        LICENSE
-Author:              Jeff Shaw
+Author:              Jeff Shaw, Ömer Sinan Ağacan
 Maintainer:          Ömer Sinan Ağacan <omeragacan@gmail.com>
 Category:            Concurrency
 Build-type:          Simple
@@ -26,30 +26,30 @@ source-repository head
 
 Library
   Exposed-modules:
+    Control.Concurrent.Chan.Class
     Control.Concurrent.Chan.ReadOnly
     Control.Concurrent.Chan.WriteOnly
+    Control.Concurrent.MVar.Class
     Control.Concurrent.MVar.ReadOnly
     Control.Concurrent.MVar.WriteOnly
     Control.Concurrent.Privileged
+    Control.Concurrent.STM.TChan.Class
     Control.Concurrent.STM.TChan.ReadOnly
     Control.Concurrent.STM.TChan.WriteOnly
+    Control.Concurrent.STM.TMVar.Class
     Control.Concurrent.STM.TMVar.ReadOnly
     Control.Concurrent.STM.TMVar.WriteOnly
+    Control.Concurrent.STM.TVar.Class
     Control.Concurrent.STM.TVar.ReadOnly
     Control.Concurrent.STM.TVar.WriteOnly
-    Control.Concurrent.MVar.Class
-    Control.Concurrent.Chan.Class
 
   Build-depends:
     base >= 4 && < 5,
     contravariant,
     lifted-base,
-    monad-control,
-    unliftio,
-    unliftio-core,
     stm,
-    transformers-base
+    unliftio,
+    unliftio-core
 
   ghc-options:        -Wall -O2
   default-language:   Haskell2010
-  default-extensions: FlexibleContexts


### PR DESCRIPTION
We use this package in a project and it becomes tiresome fast:

- Very long import names
- Need to use 2 write/read etc. function because we sometimes use `WriteOnly` variants but sometimes not
- Long import lists because we can't import the top-level module (e.g. functions clash with `Control.Concurrent.MVar` functions)
- monad-control-based functions suck because (1) most MonadBaseControl instances don't make sense (e.g. `StateT`) (2) `MonadBase base` is useless as 99.9% of the time `base` is just `IO`. We end up adding both `MonadIO` and `MonadBase IO` constraints everywhere.

This PR addresses these issues.

(incomplete)